### PR TITLE
Correctly handle save targets of 7 or higher.

### DIFF
--- a/dice.js
+++ b/dice.js
@@ -35,10 +35,12 @@ function success_chance(stat, crit, modifier) {
 
     // The critical threshold value determines when we always succeed - normally a 6.
     // 1 always fails.
-    if (crit < 2) {
-        crit = 2;
-    } else if (crit > 6) {
-        crit = 6;
+    if (crit != null) {
+        if (crit < 2) {
+            crit = 2;
+        } else if (crit > 6) {
+            crit = 6;
+        }
     }
 
     // Apply modifier to stat naively.
@@ -52,13 +54,17 @@ function success_chance(stat, crit, modifier) {
     }
 
     // Criticals always succeed.
-    if (stat > crit) {
+    if (crit && stat > crit) {
         stat = crit;
     }
 
     ret.pass_chance = (7 - stat) / 6.0;
     ret.fail_chance = 1.0 - ret.pass_chance;
-    ret.six_chance = (7 - crit) / 6.0;
+    if (crit != null) {
+        ret.six_chance = (7 - crit) / 6.0;
+    } else {
+        ret.six_chance = 0;
+    }
 
     return ret;
 }
@@ -422,7 +428,7 @@ function do_saves(save_stat, invuln_stat, ap_val, save_mod, cover, cover_max, sa
     };
     var save_title;
     if (save_stat != null) {
-        save_prob = success_chance(save_stat, 6, total_save_mod);
+        save_prob = success_chance(save_stat, null, total_save_mod);
         save_title = 'save of ' + save_stat + '+';
         if (total_save_mod) {
             var sign = '';
@@ -448,7 +454,7 @@ function do_saves(save_stat, invuln_stat, ap_val, save_mod, cover, cover_max, sa
     };
     var invuln_title;
     if (invuln_stat != null) {
-        var invuln_prob = success_chance(invuln_stat, 6, save_mod);
+        var invuln_prob = success_chance(invuln_stat, null, save_mod);
         var invuln_title = 'save of ' + invuln_stat + '++';
         if (save_mod) {
             var sign = '';
@@ -473,7 +479,7 @@ function do_saves(save_stat, invuln_stat, ap_val, save_mod, cover, cover_max, sa
         var ap_mod = parseInt(wound_abilities['pierce'], 10);
 
         // calculate save chance with modified AP.
-        var ap_save_prob = success_chance(save_stat, 6, total_save_mod - ap_mod);
+        var ap_save_prob = success_chance(save_stat, null, total_save_mod - ap_mod);
         if (save_reroll == 'fail') {
             ap_save_prob = reroll(ap_save_prob);
         } else if (save_reroll == '1') {

--- a/test.js
+++ b/test.js
@@ -625,6 +625,144 @@ function qunit_test() {
         assert.deepEqual(wounds, expected, "wounds");
     });
 
+    QUnit.module('saving throws');
+
+    QUnit.test('Two saves at 3+', function(assert) {
+        var save_stat = 3;
+        var invuln_stat = null;
+        var ap_val = 0;
+        var save_mod = 0;
+        var cover = 0;
+        var cover_max = 0;
+        var save_reroll = '';
+        var wound_abilities = {
+        };
+        var wounds = {
+            normal: [0, 0, 1],
+            mortal: [
+                [0],
+                [0],
+                [1]
+            ]
+        };
+        var wound_prob = {
+            "pass_chance": 1,
+            "fail_chance": 0,
+            "six_chance": 0
+        };
+
+        var unsaved = do_saves(save_stat, invuln_stat, ap_val, save_mod, cover, cover_max, save_reroll, wound_abilities, wounds, wound_prob);
+
+        var expected = {
+            "mortal": [
+                [
+                    0.4444444444444444
+                ],
+                [
+                    0.4444444444444445
+                ],
+                [
+                    0.11111111111111113
+                ]
+            ],
+            "normal": [
+                0.4444444444444444,
+                0.4444444444444445,
+                0.11111111111111113
+            ]
+        };
+        assert.deepEqual(unsaved, expected, "unsaved");
+    });
+
+    QUnit.test('Two saves at 3+ (AP -4)', function(assert) {
+        var save_stat = 3;
+        var invuln_stat = null;
+        var ap_val = 4;
+        var save_mod = 0;
+        var cover = 0;
+        var cover_max = 0;
+        var save_reroll = '';
+        var wound_abilities = {
+        };
+        var wounds = {
+            normal: [0, 0, 1],
+            mortal: [
+                [0],
+                [0],
+                [1]
+            ]
+        };
+        var wound_prob = {
+            "pass_chance": 1,
+            "fail_chance": 0,
+            "six_chance": 0
+        };
+
+        var unsaved = do_saves(save_stat, invuln_stat, ap_val, save_mod, cover, cover_max, save_reroll, wound_abilities, wounds, wound_prob);
+
+        var expected = {
+            "mortal": [
+                [0],
+                [0],
+                [1]
+            ],
+            "normal": [
+                0,
+                0,
+                1
+            ]
+        };
+        assert.deepEqual(unsaved, expected, "unsaved");
+    });
+
+
+    QUnit.test('Two saves at 3+ (AP -3), invuln 5+', function(assert) {
+        var save_stat = 3;
+        var invuln_stat = 5;
+        var ap_val = 3;
+        var save_mod = 0;
+        var cover = 0;
+        var cover_max = 0;
+        var save_reroll = '';
+        var wound_abilities = {
+        };
+        var wounds = {
+            normal: [0, 0, 1],
+            mortal: [
+                [0],
+                [0],
+                [1]
+            ]
+        };
+        var wound_prob = {
+            "pass_chance": 1,
+            "fail_chance": 0,
+            "six_chance": 0
+        };
+
+        var unsaved = do_saves(save_stat, invuln_stat, ap_val, save_mod, cover, cover_max, save_reroll, wound_abilities, wounds, wound_prob);
+
+        var expected = {
+            "mortal": [
+                [
+                    0.11111111111111106
+                ],
+                [
+                    0.4444444444444444
+                ],
+                [
+                    0.44444444444444453
+                ]
+            ],
+            "normal": [
+                0.11111111111111106,
+                0.4444444444444444,
+                0.44444444444444453
+            ]
+        };
+        assert.deepEqual(unsaved, expected, "unsaved");
+    });
+
     QUnit.module('damage & kills');
 
     QUnit.test('40K multiwound', function(assert) {


### PR DESCRIPTION
This was an error caused by refactoring to support variable crit targets. Saving throws do not always succeed on a 6. Also added unit tests.

Fixes #13.